### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.Primitives.Time.Operations/Pure.Primitives.Time.Operations.csproj
+++ b/src/Pure.Primitives.Time.Operations/Pure.Primitives.Time.Operations.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.4.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Primitives.Time.Operations</PackageId>


### PR DESCRIPTION
Closes #90

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.